### PR TITLE
prettier should be installed as a dev dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ npm install @twostoryrobot/prettier
 Make sure to install the peer dependencies
 
 ```bash
-npm install prettier
+npm install --save-dev prettier
 ```
 
 ### Scripts

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ prettier config in this repo. It is recommended to add `.prettierrc` to your
 `.gitignore` so you don't accidentally commit the symlink.
 
 ```bash
-npm install @twostoryrobot/prettier
+npm install --save-dev @twostoryrobot/prettier
 ```
 
 Make sure to install the peer dependencies


### PR DESCRIPTION
updated instructions to install prettier as a dev dependency not a regular dependency