### PR TITLE
v2.0.0 - Change config to be an exported JS object

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,21 @@
 
 ## Usage
 
-Installing the package will make a symlink in the root of your project to the
-prettier config in this repo. It is recommended to add `.prettierrc` to your
-`.gitignore` so you don't accidentally commit the symlink.
-
 ```bash
 npm install --save-dev @twostoryrobot/prettier
+```
+
+Then you can source the config from your own `prettier.config.js`.
+
+```js
+module.exports = require('@twostoryrobot/prettier')
+```
+
+Or if you want to override the default at all.
+
+```js
+const prettierConfig = require('@twostoryrobot/prettier')
+module.exports = Object.assign({}, prettierConfig, { semi: true })
 ```
 
 Make sure to install the peer dependencies

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ Then you can source the config from your own `prettier.config.js`.
 module.exports = require('@twostoryrobot/prettier')
 ```
 
-Or if you want to override the default at all.
+Or if you want to override the default at all (Note: please consider making a PR
+if you think the override will be useful for other projects).
 
 ```js
 const prettierConfig = require('@twostoryrobot/prettier')

--- a/package.json
+++ b/package.json
@@ -2,10 +2,7 @@
   "name": "@twostoryrobot/prettier",
   "version": "1.0.0",
   "description": "prettier configuration for Two Story Robot",
-  "main": "index.js",
-  "scripts": {
-    "postinstall": "ln -fs $(pwd)/prettierrc $(pwd)/../../../.prettierrc"
-  },
+  "main": "prettier.config.js",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/TwoStoryRobot/prettier-config.git"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twostoryrobot/prettier",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "prettier configuration for Two Story Robot",
   "main": "prettier.config.js",
   "repository": {

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,9 +1,5 @@
 module.exports = {
-  "semi": false,
-  "singleQuote": true,
-  "jsxBracketSameLine": true,
-  "overrides": [{
-    "files": ".prettierrc",
-    "options": { "parser": "json" }
-  }]
+  semi: false,
+  singleQuote: true,
+  jsxBracketSameLine: true
 }

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,4 +1,4 @@
-{
+module.exports = {
   "semi": false,
   "singleQuote": true,
   "jsxBracketSameLine": true,


### PR DESCRIPTION
Change config to be an exported JS object which can be sources, and optionally overridden, from the project's root `prettier.config.js`.