### PR TITLE
add MIT license file, rename to prettier-config

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 Two Story Robot
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![npm (scoped)](https://img.shields.io/npm/v/@twostoryrobot/prettier.svg)](https://www.npmjs.com/package/@twostoryrobot/prettier)
+[![npm (scoped)](https://img.shields.io/npm/v/@twostoryrobot/prettier-config.svg)](https://www.npmjs.com/package/@twostoryrobot/prettier-config)
 
 
 # 2SR prettier
@@ -8,20 +8,20 @@ Get pretty code with prettier the way Two Story Robot likes it.
 ## Usage
 
 ```bash
-npm install --save-dev @twostoryrobot/prettier
+npm install --save-dev @twostoryrobot/prettier-config
 ```
 
 Then you can source the config from your own `prettier.config.js`.
 
 ```js
-module.exports = require('@twostoryrobot/prettier')
+module.exports = require('@twostoryrobot/prettier-config')
 ```
 
 Or if you want to override the default at all (Note: please consider making a PR
 if you think the override will be useful for other projects).
 
 ```js
-const prettierConfig = require('@twostoryrobot/prettier')
+const prettierConfig = require('@twostoryrobot/prettier-config')
 module.exports = Object.assign({}, prettierConfig, { semi: true })
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@twostoryrobot/prettier",
+  "name": "@twostoryrobot/prettier-config",
   "version": "2.0.0",
   "description": "prettier configuration for Two Story Robot",
   "main": "prettier.config.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twostoryrobot/prettier-config",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "prettier configuration for Two Story Robot",
   "main": "prettier.config.js",
   "repository": {


### PR DESCRIPTION
We should include the MIT license file for clarity. Also renamed to `prettier-config` for consistency with [twostoryrobot/eslint-config](https://github.com/TwoStoryRobot/eslint-config)

Fixes #5 
Fixes #6 

### Tasks

* [ ] Publish on NPM
* [ ] Deprecate old `@twostoryrobot/prettier` package