### PR TITLE
Update README to not recommend peerdep explicit install

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 [![npm (scoped)](https://img.shields.io/npm/v/@twostoryrobot/prettier-config.svg)](https://www.npmjs.com/package/@twostoryrobot/prettier-config)
 
-
-# 2SR prettier
+# TSR prettier
 
 Get pretty code with prettier the way Two Story Robot likes it.
 
@@ -17,41 +16,24 @@ Then you can source the config from your own `.prettierrc.js`.
 module.exports = require('@twostoryrobot/prettier-config')
 ```
 
-Or if you want to override the default at all (Note: please consider making a PR
-if you think the override will be useful for other projects).
+Now you can add a script to your project's package.json that calls prettier and
+it will reference the config file in the root of your project directory.
+
+```json
+"scripts": {
+  "prettier": "prettier --write 'src/**/*.js'",
+  "prettier-check": "prettier --list-different 'src/**/*.js'"
+}
+```
+
+## Custom configuration
+
+If you want to override the defaults at all, use this method:
 
 ```js
 const prettierConfig = require('@twostoryrobot/prettier-config')
 module.exports = Object.assign({}, prettierConfig, { semi: true })
 ```
 
-Make sure to install the peer dependencies
-
-```bash
-npx install-peerdeps --dev @twostoryrobot/prettier-config
-```
-
-### Scripts
-
-Now you can add a script to your project's package.json that calls prettier and
-it will reference the config file in the root of your project directory.
-
-```json
-"scripts": {
-  "prettier": "prettier --write '**/*.js'"
-}
-```
-
-### Hooks
-
-If you install [husky](https://github.com/typicode/husky) you can invoke
-prettier as a hook for various actions (precommit, prepush, etc)
-
-```json
- "husky": {
-    "hooks": {
-      "pre-commit": "prettier --list-different '**/*.js'"
-    }
-  }
-}
-```
+_Note: please consider making a PR if you think the override will be useful for
+other projects._


### PR DESCRIPTION
npm's new default behaviour for peerdeps is better than explicitly installing them.